### PR TITLE
fix: keep noble in mainnet chain-info config

### DIFF
--- a/deploy/tools/chain-info.build.js
+++ b/deploy/tools/chain-info.build.js
@@ -274,7 +274,7 @@ const pickKeys = (obj, wanted) =>
 
 /** @param {Array<keyof typeof fetchedChainInfo>} chains */
 const getMainnetChainInfo = (
-  chains = ['agoric', 'osmosis', 'axelar', 'neutron'],
+  chains = ['agoric', 'axelar', 'noble', 'neutron', 'osmosis'],
 ) => {
   console.log('using static mainnet config');
   return harden(pickKeys(fetchedChainInfo, chains));


### PR DESCRIPTION
ensure that all current chains are included in the static mainnet config

fixes #40 

attn @JoE11-y
cc @rabi-siddique